### PR TITLE
Use HTTPS when downloading from UCSC

### DIFF
--- a/liftover/lifter.py
+++ b/liftover/lifter.py
@@ -31,7 +31,7 @@ def get_lifter(target, query, cache=None):
     chain_path = os.path.join(cache, basename)
     
     if not os.path.exists(chain_path):
-        url = 'http://hgdownload.cse.ucsc.edu/goldenPath/{}/liftOver/{}'.format(target, basename)
+        url = 'https://hgdownload.cse.ucsc.edu/goldenPath/{}/liftOver/{}'.format(target, basename)
         download_file(url, chain_path)
     
     return ChainFile(chain_path, target, query)


### PR DESCRIPTION
I'm trying to use this package currently, and trying to download a chain from UCSC seems to be hanging indefinitely when using HTTP. When I try manually using HTTPS things seem to work smoothly, so it may be time to update the URL to https.